### PR TITLE
Add port 443 for dwellir endpoints

### DIFF
--- a/prometheus-master.yml
+++ b/prometheus-master.yml
@@ -63,6 +63,6 @@ scrape_configs:
       "match[]":
         - '{job="Dwellir"}'
     static_configs:
-      - targets: ['rpc-monitoring-se1.dwellir.com']
-      - targets: ['rpc-monitoring-se2.dwellir.com']
-      - targets: ['rpc-monitoring-tn.dwellir.com']
+      - targets: ['rpc-monitoring-se1.dwellir.com:443']
+      - targets: ['rpc-monitoring-se2.dwellir.com:443']
+      - targets: ['rpc-monitoring-tn.dwellir.com:443']

--- a/prometheus-master.yml
+++ b/prometheus-master.yml
@@ -59,10 +59,11 @@ scrape_configs:
     scrape_interval: 15s
     honor_labels: true
     metrics_path: "/federate"
+    scheme: https
     params:
       "match[]":
         - '{job="Dwellir"}'
     static_configs:
-      - targets: ['rpc-monitoring-se1.dwellir.com:443']
-      - targets: ['rpc-monitoring-se2.dwellir.com:443']
-      - targets: ['rpc-monitoring-tn.dwellir.com:443']
+      - targets: ['rpc-monitoring-se1.dwellir.com']
+      - targets: ['rpc-monitoring-se2.dwellir.com']
+      - targets: ['rpc-monitoring-tn.dwellir.com']


### PR DESCRIPTION
Let's try and add the port 443, if the central-prometheus is running on IP 18.156.32.189 then this should work.