### PR TITLE
Add RadiumBlock metrics to Prometheus configuration

### DIFF
--- a/prometheus-master.yml
+++ b/prometheus-master.yml
@@ -110,7 +110,7 @@ scrape_configs:
       - targets:
         - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
         labels:
-          __metrics_path__: /bridehub-kusama
+          __metrics_path__: /bridgehub-kusama
       - targets:
         - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
         labels:

--- a/prometheus-master.yml
+++ b/prometheus-master.yml
@@ -107,6 +107,30 @@ scrape_configs:
         - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
         labels:
           __metrics_path__: /statemint
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /bridehub-kusama
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /collectives
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /people-polkadot
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /people-kusama
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /coretime-polkadot
+      - targets:
+        - "polkadot-public-rpc.prometheus.radiumblock.co:80"   
+        labels:
+          __metrics_path__: /westend    
   # onfinality
   - job_name: "onfinality"
     scrape_interval: 15s


### PR DESCRIPTION
Adds RadiumBlock metrics to prometheus-master.yml to enable monitoring and alerting for RadiumBlock RPC endpoints. This update ensures RadiumBlock is included in the central Prometheus scrape configuration alongside other supported providers.